### PR TITLE
Method honeypot_string allows disguising honeypot name

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -71,6 +71,13 @@ add your own custom field names and values. For example:
       }
     end
 
+Override the `honeypot_string` method within `ApplicationController` to
+disguise the string that will be included in the honeypot name. For example:
+
+    def honeypot_string
+      'im-not-a-honeypot-at-all'
+    end
+
 ## Note on Patches/Pull Requests
 
 * Fork the project.

--- a/lib/honeypot-captcha.rb
+++ b/lib/honeypot-captcha.rb
@@ -6,12 +6,17 @@ module HoneypotCaptcha
       { :a_comment_body => 'Do not fill in this field' }
     end
 
+    def honeypot_string
+      'hp'
+    end
+
     def protect_from_spam
       head :ok if honeypot_fields.any? { |f,l| !params[f].blank? }
     end
 
     def self.included(base) # :nodoc:
       base.send :helper_method, :honeypot_fields
+      base.send :helper_method, :honeypot_string
 
       if base.respond_to? :before_filter
         base.send :prepend_before_filter, :protect_from_spam, :only => [:create, :update]

--- a/lib/honeypot-captcha/form_tag_helper.rb
+++ b/lib/honeypot-captcha/form_tag_helper.rb
@@ -22,7 +22,7 @@ module ActionView
       def honey_pot_captcha
         html_ids = []
         honeypot_fields.collect do |f, l|
-          html_ids << (html_id = "#{f}_hp_#{Time.now.to_i}")
+          html_ids << (html_id = "#{f}_#{honeypot_string}_#{Time.now.to_i}")
           content_tag :div, :id => html_id do
             content_tag(:style, :type => 'text/css', :media => 'screen', :scoped => "scoped") do
               "#{html_ids.map { |i| "##{i}" }.join(', ')} { display:none; }"


### PR DESCRIPTION
Simple change to allow altering the honeypot name, in case any malicious users get wise to the hardcoded 'hp' string.
