### PR TITLE
sanitize generated html id

### DIFF
--- a/lib/honeypot-captcha/form_tag_helper.rb
+++ b/lib/honeypot-captcha/form_tag_helper.rb
@@ -22,7 +22,7 @@ module ActionView
       def honey_pot_captcha
         html_ids = []
         honeypot_fields.collect do |f, l|
-          html_ids << (html_id = "#{f}_#{honeypot_string}_#{Time.now.to_i}")
+          html_ids << (html_id = sanitize_html_id("#{f}_#{honeypot_string}_#{Time.now.to_i}"))
           content_tag :div, :id => html_id do
             content_tag(:style, :type => 'text/css', :media => 'screen', :scoped => "scoped") do
               "#{html_ids.map { |i| "##{i}" }.join(', ')} { display:none; }"
@@ -31,6 +31,10 @@ module ActionView
             send([:text_field_tag, :text_area_tag][rand(2)], f)
           end
         end.join
+      end
+
+      def sanitize_html_id(value)
+        value.gsub(/\]\[|[^-a-zA-Z0-9:.]/, "_")
       end
     end
   end


### PR DESCRIPTION
when the honeypot_fields contains a key that has certain characters, it will generate an incorrect css selector. E.g. if the key is `post[title]`, the generated style looks like
```
#post[title]_hp_1243244 { display: none; }
```
which won't target the generated div.