### PR TITLE
Method honeypot_style_class allows non-inline styling

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -55,7 +55,7 @@ honeypot protection, simply add the before filter for that action
 in your controller. For example:
 
     class NewsletterController < ApplicationController
-      prepend_before_filter :protect_from_spam, :only => [:subscribe]
+      prepend_before_action :protect_from_spam, :only => [:subscribe]
       ...
     end
 

--- a/README.markdown
+++ b/README.markdown
@@ -78,6 +78,24 @@ disguise the string that will be included in the honeypot name. For example:
       'im-not-a-honeypot-at-all'
     end
 
+Override the `honeypot_style_class` method within `ApplicationController` to
+provide a non-inline CSS class that will be applied to hide honeypot fields
+(if nil, the style will be applied inline). For example:
+
+    def honeypot_style_class
+      'display-none'
+    end
+
+... assigns an HTML class for styling purposes:
+
+    <div id="login_hp_1464171481" class="display-none">
+
+... which can be styled by a CSS style within app/assets/stylesheets:
+
+    .display-none {
+      display: none;
+    }
+
 ## Note on Patches/Pull Requests
 
 * Fork the project.

--- a/lib/honeypot-captcha.rb
+++ b/lib/honeypot-captcha.rb
@@ -10,6 +10,10 @@ module HoneypotCaptcha
       'hp'
     end
 
+    def honeypot_style_class
+      nil
+    end
+
     def protect_from_spam
       head :ok if honeypot_fields.any? { |f,l| !params[f].blank? }
     end
@@ -17,6 +21,7 @@ module HoneypotCaptcha
     def self.included(base) # :nodoc:
       base.send :helper_method, :honeypot_fields
       base.send :helper_method, :honeypot_string
+      base.send :helper_method, :honeypot_style_class
 
       if base.respond_to? :before_filter
         base.send :prepend_before_filter, :protect_from_spam, :only => [:create, :update]

--- a/lib/honeypot-captcha.rb
+++ b/lib/honeypot-captcha.rb
@@ -23,7 +23,9 @@ module HoneypotCaptcha
       base.send :helper_method, :honeypot_string
       base.send :helper_method, :honeypot_style_class
 
-      if base.respond_to? :before_filter
+      if base.respond_to? :before_action
+        base.send :prepend_before_action, :protect_from_spam, :only => [:create, :update]
+      elsif base.respond_to? :before_filter
         base.send :prepend_before_filter, :protect_from_spam, :only => [:create, :update]
       end
     end

--- a/lib/honeypot-captcha/form_tag_helper.rb
+++ b/lib/honeypot-captcha/form_tag_helper.rb
@@ -19,17 +19,25 @@ module ActionView
 
     private
 
+      def style_attributes
+        honeypot_style_class ? {:class => honeypot_style_class} : {}
+      end
+
+      def style_tag(html_ids)
+        honeypot_style_class ? '' : content_tag(:style, :type => 'text/css', :media => 'screen', :scoped => "scoped") { "#{html_ids.map { |i| "##{i}" }.join(', ')} { display:none; }" }
+      end
+
       def honey_pot_captcha
         html_ids = []
         honeypot_fields.collect do |f, l|
           html_ids << (html_id = "#{f}_#{honeypot_string}_#{Time.now.to_i}")
-          content_tag :div, :id => html_id do
-            content_tag(:style, :type => 'text/css', :media => 'screen', :scoped => "scoped") do
-              "#{html_ids.map { |i| "##{i}" }.join(', ')} { display:none; }"
-            end +
+
+          content_tag :div, {:id => html_id}.merge(style_attributes) do
+            style_tag(html_ids).html_safe +
             label_tag(f, l) +
             send([:text_field_tag, :text_area_tag][rand(2)], f)
           end
+
         end.join
       end
     end

--- a/lib/honeypot-captcha/form_tag_helper.rb
+++ b/lib/honeypot-captcha/form_tag_helper.rb
@@ -15,7 +15,8 @@ module ActionView
         end
         html
       end
-      alias_method_chain :form_tag_html, :honeypot
+      alias_method :form_tag_html_without_honeypot, :form_tag_html
+      alias_method :form_tag_html, :form_tag_html_with_honeypot
 
     private
 


### PR DESCRIPTION
Allow providing an optional CSS class for styling the honeypot (this CSS class should hide the honeypot). Providing a style in this manner avoids inline styling that typically violates [Content Security Policy (CSP)](http://en.wikipedia.org/wiki/Content_Security_Policy).

If this CSS class is omitted, the honeypot will be styled using inline styling as before.
