### PR TITLE
Dropped support for Ruby < 2.0.0

### DIFF
--- a/lib/honeypot-captcha.rb
+++ b/lib/honeypot-captcha.rb
@@ -18,8 +18,14 @@ module HoneypotCaptcha
       base.send :helper_method, :honeypot_fields
       base.send :helper_method, :honeypot_string
 
-      if base.respond_to? :before_filter
-        base.send :prepend_before_filter, :protect_from_spam, :only => [:create, :update]
+      callback_to_add = if base.respond_to?(:before_action)
+                          :prepend_before_action
+                        elsif base.respond_to?(:before_filter)
+                          :prepend_before_filter
+                        end
+
+      if callback_to_add
+        base.send callback_to_add, :protect_from_spam, :only => [:create, :update]
       end
     end
   end

--- a/lib/honeypot-captcha/form_tag_helper.rb
+++ b/lib/honeypot-captcha/form_tag_helper.rb
@@ -1,37 +1,41 @@
+module HoneyPotFormTag
+  def form_tag_html(options)
+    honeypot = options.delete(:honeypot) || options.delete('honeypot')
+    html = super(options)
+    if honeypot
+      captcha = "".respond_to?(:html_safe) ? honey_pot_captcha.html_safe : honey_pot_captcha
+      if block_given?
+        html.insert(html.index('</form>'), captcha)
+      else
+        html += captcha
+      end
+    end
+    html
+  end
+
+  private
+
+  def honey_pot_captcha
+    html_ids = []
+    honeypot_fields.collect do |f, l|
+      html_ids << (html_id = "#{f}_#{honeypot_string}_#{Time.now.to_i}")
+      content_tag :div, :id => html_id do
+        content_tag(:style, :type => 'text/css', :media => 'screen', :scoped => "scoped") do
+          "#{html_ids.map { |i| "##{i}" }.join(', ')} { display:none; }"
+        end +
+        label_tag(f, l) +
+        send([:text_field_tag, :text_area_tag][rand(2)], f)
+      end
+    end.join
+  end
+end
+
 # Override the form_tag helper to add honeypot spam protection to forms.
 module ActionView
   module Helpers
     module FormTagHelper
-      def form_tag_html_with_honeypot(options)
-        honeypot = options.delete(:honeypot) || options.delete('honeypot')
-        html = form_tag_html_without_honeypot(options)
-        if honeypot
-          captcha = "".respond_to?(:html_safe) ? honey_pot_captcha.html_safe : honey_pot_captcha
-          if block_given?
-            html.insert(html.index('</form>'), captcha)
-          else
-            html += captcha
-          end
-        end
-        html
-      end
-      alias_method_chain :form_tag_html, :honeypot
-
-    private
-
-      def honey_pot_captcha
-        html_ids = []
-        honeypot_fields.collect do |f, l|
-          html_ids << (html_id = "#{f}_#{honeypot_string}_#{Time.now.to_i}")
-          content_tag :div, :id => html_id do
-            content_tag(:style, :type => 'text/css', :media => 'screen', :scoped => "scoped") do
-              "#{html_ids.map { |i| "##{i}" }.join(', ')} { display:none; }"
-            end +
-            label_tag(f, l) +
-            send([:text_field_tag, :text_area_tag][rand(2)], f)
-          end
-        end.join
-      end
+      prepend ::HoneyPotFormTag
     end
   end
 end
+


### PR DESCRIPTION
Removed use of alias_method_chain in favour of Ruby 2.0.0's prepend functionality. Using `prepend_before_action` instead of `prepend_before_filter` when possible. This removes deprecation warnings in Rails 5.