### PR TITLE
Removes alias_method_chain

### DIFF
--- a/lib/honeypot-captcha/form_tag_helper.rb
+++ b/lib/honeypot-captcha/form_tag_helper.rb
@@ -15,9 +15,10 @@ module ActionView
         end
         html
       end
-      alias_method_chain :form_tag_html, :honeypot
+      alias_method :form_tag_html_without_honeypot, :form_tag_html
+      alias_method :form_tag_html, :form_tag_html_with_honeypot
 
-    private
+      private
 
       def honey_pot_captcha
         html_ids = []


### PR DESCRIPTION
Removes alias_method_chain to make compatible with Rails 5.1.2