### PR TITLE
Fix deprecated prepend_before_filter

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -55,7 +55,7 @@ honeypot protection, simply add the before filter for that action
 in your controller. For example:
 
     class NewsletterController < ApplicationController
-      prepend_before_filter :protect_from_spam, :only => [:subscribe]
+      prepend_before_action :protect_from_spam, :only => [:subscribe]
       ...
     end
 

--- a/lib/honeypot-captcha.rb
+++ b/lib/honeypot-captcha.rb
@@ -18,7 +18,9 @@ module HoneypotCaptcha
       base.send :helper_method, :honeypot_fields
       base.send :helper_method, :honeypot_string
 
-      if base.respond_to? :before_filter
+      if base.respond_to? :before_action
+        base.send :prepend_before_action, :protect_from_spam, :only => [:create, :update]
+      elsif base.respond_to? :before_filter
         base.send :prepend_before_filter, :protect_from_spam, :only => [:create, :update]
       end
     end


### PR DESCRIPTION
Replace deprecated `prepend_before_filter` to be compatible with Rails 5.1.

Both this pull request and pull request #16 are merged into `master` at https://github.com/sunny/honeypot-captcha