### PR TITLE
Fix Rails 6 load deprecation warning

### DIFF
--- a/lib/honeypot-captcha.rb
+++ b/lib/honeypot-captcha.rb
@@ -32,4 +32,6 @@ module HoneypotCaptcha
   end
 end
 
-ActionController::Base.send(:include, HoneypotCaptcha::SpamProtection) if defined?(ActionController::Base)
+ActiveSupport.on_load(:action_controller) do
+  include HoneypotCaptcha::SpamProtection
+end

--- a/lib/honeypot-captcha.rb
+++ b/lib/honeypot-captcha.rb
@@ -33,5 +33,7 @@ module HoneypotCaptcha
 end
 
 ActiveSupport.on_load(:action_controller) do
-  include HoneypotCaptcha::SpamProtection
+  if defined?(ActionController::Base)
+    ActionController::Base.send(:include, HoneypotCaptcha::SpamProtection)
+  end
 end


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Fixes `DEPRECATION WARNING: Initialization autoloaded the constants ActionText::ContentHelper and ActionText::TagHelper`.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes #40 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Use the [Rails's guide's engine hooks](https://guides.rubyonrails.org/engines.html#what-are-on-load-hooks-questionmark) to load helpers.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] <del>My change requires a change to the documentation.</del>
- [x] <del>I have updated the documentation accordingly.</del>
- [x] I have read the **CONTRIBUTING** document.
