### PR TITLE
Prevent whitespace from passing honeypot checks

### DIFF
--- a/lib/honeypot-captcha.rb
+++ b/lib/honeypot-captcha.rb
@@ -15,7 +15,7 @@ module HoneypotCaptcha
     end
 
     def protect_from_spam
-      head :ok if honeypot_fields.any? { |f,l| !params[f].blank? }
+      head :ok if honeypot_fields.any? { |f,l| !params[f].blank? || params[f].to_s.length > 0 }
     end
 
     def self.included(base) # :nodoc:


### PR DESCRIPTION
## Description
When a honeypot field is filled with a newline (`"\n"`), `protect_from_spam` does not properly block the request. This is because `"\n".blank?` returns true. 

## Related Issue
https://github.com/curtis/honeypot-captcha/issues/47

## Motivation and Context
As described in the description, this change will make `protect_from_spam` more robust and block requests where there are any values in the honeypot fields. 

## Screenshots (if appropriate):
N/A
## Types of changes
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
