### PR TITLE
The honeypot field needs to be present in the post request

### DIFF
--- a/lib/honeypot-captcha.rb
+++ b/lib/honeypot-captcha.rb
@@ -15,7 +15,7 @@ module HoneypotCaptcha
     end
 
     def protect_from_spam
-      head :ok if honeypot_fields.any? { |f,l| !params[f].blank? }
+      head :ok if honeypot_fields.any? { |f,l| !params[f].blank? || params[f].nil? }
     end
 
     def self.included(base) # :nodoc:


### PR DESCRIPTION
## Description
The filter should also prevent the request from hitting the controller if it does not include the honeypot field. 
Bots that have the POST request cached somewhere prior to using this solution are bypassing honeypot-captcha as they are not including the new dummy field.

## Related Issue
https://github.com/curtis/honeypot-captcha/issues/60

## Motivation and Context
This will also prevent bots with stored requests from sending spam. Especially interesting for forms that have been online for some time.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
